### PR TITLE
Replace deprecated functions getCart and generateRedirectFromRoute

### DIFF
--- a/Controller/EditPrices.php
+++ b/Controller/EditPrices.php
@@ -87,7 +87,7 @@ class EditPrices extends BaseAdminController
             throw new \ErrorException("Arguments are missing or invalid");
           }
 
-        $this->generateRedirectFromRoute("admin.module.configure",array(),
+        return $this->generateRedirectFromRoute("admin.module.configure",array(),
             array (
                 'current_tab'=>'price_slices_tab',
                 'module_code'=>"SoColissimo",

--- a/Controller/EditPrices.php
+++ b/Controller/EditPrices.php
@@ -87,7 +87,7 @@ class EditPrices extends BaseAdminController
             throw new \ErrorException("Arguments are missing or invalid");
           }
 
-        $this->redirectToRoute("admin.module.configure",array(),
+        $this->generateRedirectFromRoute("admin.module.configure",array(),
             array (
                 'current_tab'=>'price_slices_tab',
                 'module_code'=>"SoColissimo",

--- a/SoColissimo.php
+++ b/SoColissimo.php
@@ -69,7 +69,7 @@ class SoColissimo extends AbstractDeliveryModule
      */
     public function isValidDelivery(Country $country)
     {
-        $cartWeight = $this->getRequest()->getSession()->getCart()->getWeight();
+        $cartWeight = $this->getRequest()->getSession()->getSessionCart()->getWeight();
 
         $areaId = $country->getAreaId();
 
@@ -147,7 +147,7 @@ class SoColissimo extends AbstractDeliveryModule
      */
     public function getPostage(Country $country)
     {
-        $cartWeight = $this->getRequest()->getSession()->getCart()->getWeight();
+        $cartWeight = $this->getRequest()->getSession()->getSessionCart()->getWeight();
 
         $postage = self::getPostageAmount(
             $country->getAreaId(),

--- a/SoColissimo.php
+++ b/SoColissimo.php
@@ -69,7 +69,7 @@ class SoColissimo extends AbstractDeliveryModule
      */
     public function isValidDelivery(Country $country)
     {
-        $cartWeight = $this->getRequest()->getSession()->getSessionCart()->getWeight();
+        $cartWeight = $this->getRequest()->getSession()->getSessionCart($this->getDispatcher())->getWeight();
 
         $areaId = $country->getAreaId();
 
@@ -147,7 +147,7 @@ class SoColissimo extends AbstractDeliveryModule
      */
     public function getPostage(Country $country)
     {
-        $cartWeight = $this->getRequest()->getSession()->getSessionCart()->getWeight();
+        $cartWeight = $this->getRequest()->getSession()->getSessionCart($this->getDispatcher())->getWeight();
 
         $postage = self::getPostageAmount(
             $country->getAreaId(),


### PR DESCRIPTION
getCart and generateRedirectFromRoute are deprecated on Thelia v2.1.2.