### PR TITLE
More information for deliveries at relays in PDF order invoices

### DIFF
--- a/Config/config.xml
+++ b/Config/config.xml
@@ -12,6 +12,7 @@
         <loop class="SoColissimo\Loop\GetRelais" name="socolissimo.around" />
         <loop class="SoColissimo\Loop\SoColissimoAddress" name="address.socolissimo" />
         <loop class="SoColissimo\Loop\NotSentOrders" name="order.notsent.socolissimo" />
+        <loop class="SoColissimo\Loop\SoColissimoOrderAddressLoop" name="socolissimo.order_address" />
     </loops>
 
     <forms>
@@ -44,6 +45,9 @@
             <tag name="hook.event_listener" event="order-delivery.extra" />
             <tag name="hook.event_listener" event="order-invoice.delivery-address" />
             <tag name="hook.event_listener" event="main.head-bottom" />
+        </hook>
+        <hook id="socolissimo.hook.pdf" class="SoColissimo\Hook\PdfHook" scope="request">
+            <tag name="hook.event_listener" event="invoice.after-delivery-module" type="pdf" method="onInvoiceAfterDeliveryModule" />
         </hook>
     </hooks>
 

--- a/Hook/PdfHook.php
+++ b/Hook/PdfHook.php
@@ -1,0 +1,31 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace SoColissimo\Hook;
+
+use SoColissimo\SoColissimo;
+use Thelia\Core\Event\Hook\HookRenderEvent;
+use Thelia\Core\Hook\BaseHook;
+use Thelia\Model\OrderQuery;
+
+class PdfHook extends BaseHook
+{
+    public function onInvoiceAfterDeliveryModule(HookRenderEvent $event)
+    {
+            (SoColissimo::getModuleId() == $event->getArgument('module_id'))
+        and !(is_null($order = OrderQuery::create()->findOneById($event->getArgument('order'))))
+        and $event->add($this->render(
+            'delivery_mode_infos.html',
+            ['delivery_address_id' => $order->getDeliveryOrderAddressId()]
+        ));
+    }
+}

--- a/Hook/PdfHook.php
+++ b/Hook/PdfHook.php
@@ -21,11 +21,18 @@ class PdfHook extends BaseHook
 {
     public function onInvoiceAfterDeliveryModule(HookRenderEvent $event)
     {
-            (SoColissimo::getModuleId() == $event->getArgument('module_id'))
-        and !(is_null($order = OrderQuery::create()->findOneById($event->getArgument('order'))))
-        and $event->add($this->render(
-            'delivery_mode_infos.html',
-            ['delivery_address_id' => $order->getDeliveryOrderAddressId()]
-        ));
+        // No So Colissimo information if the delivery module is not SoColissimo
+        if (SoColissimo::getModuleId() == $event->getArgument('module_id')) {
+            return;
+        }
+
+        $order = OrderQuery::create()->findOneById($event->getArgument('order'));
+
+        if (!is_null($order)) {
+            $event->add($this->render(
+                'delivery_mode_infos.html',
+                ['delivery_address_id' => $order->getDeliveryOrderAddressId()]
+            ));
+        }
     }
 }

--- a/I18n/pdf/default/en_US.php
+++ b/I18n/pdf/default/en_US.php
@@ -1,0 +1,9 @@
+<?php
+return array(
+    'Delivered at a relay.' => 'Delivered at a relay.',
+    'Delivered at home.' => 'Delivered at home.',
+    'yes' => 'yes',
+    'no' => 'no',
+    'no address' => 'no address',
+    'Relay address:' => 'Relay address:',
+);

--- a/I18n/pdf/default/fr_FR.php
+++ b/I18n/pdf/default/fr_FR.php
@@ -1,0 +1,9 @@
+<?php
+return array(
+    'Delivered at a relay.' => 'Livré en point relais.',
+    'Delivered at home.' => 'Livré à domicile.',
+    'yes' => 'oui',
+    'no' => 'non',
+    'no address' => 'pas d\'adresse',
+    'Relay address:' => 'Adresse du point relais :',
+);

--- a/Loop/SoColissimoOrderAddressLoop.php
+++ b/Loop/SoColissimoOrderAddressLoop.php
@@ -58,7 +58,11 @@ class SoColissimoOrderAddressLoop extends BaseLoop implements PropelSearchLoopIn
     public function buildModelCriteria()
     {
         $query = OrderAddressSocolissimoQuery::create();
-        !(is_null($id = $this->getId())) and $query->filterById(intval($id));
+
+        if (!is_null($id = $this->getId())) {
+            $query->filterById(intval($id));
+        }
+
         return $query;
     }
 

--- a/Loop/SoColissimoOrderAddressLoop.php
+++ b/Loop/SoColissimoOrderAddressLoop.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ducher
+ * Date: 17/06/15
+ * Time: 11:18
+ */
+
+namespace SoColissimo\Loop;
+
+use SoColissimo\Model\OrderAddressSocolissimo;
+use SoColissimo\Model\OrderAddressSocolissimoQuery;
+use Thelia\Core\Template\Element\BaseLoop;
+use Thelia\Core\Template\Element\LoopResult;
+use Thelia\Core\Template\Element\LoopResultRow;
+use Thelia\Core\Template\Element\PropelSearchLoopInterface;
+use Thelia\Core\Template\Loop\Argument\Argument;
+use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
+
+class SoColissimoOrderAddressLoop extends BaseLoop implements PropelSearchLoopInterface
+{
+    /**
+     * Definition of loop arguments
+     *
+     * example :
+     *
+     * public function getArgDefinitions()
+     * {
+     *  return new ArgumentCollection(
+     *
+     *       Argument::createIntListTypeArgument('id'),
+     *           new Argument(
+     *           'ref',
+     *           new TypeCollection(
+     *               new Type\AlphaNumStringListType()
+     *           )
+     *       ),
+     *       Argument::createIntListTypeArgument('category'),
+     *       Argument::createBooleanTypeArgument('new'),
+     *       ...
+     *   );
+     * }
+     *
+     * @return \Thelia\Core\Template\Loop\Argument\ArgumentCollection
+     */
+    protected function getArgDefinitions()
+    {
+        return new ArgumentCollection(
+            Argument::createIntTypeArgument('id', null, true)
+        );
+    }
+
+    /**
+     * this method returns a Propel ModelCriteria
+     *
+     * @return \Propel\Runtime\ActiveQuery\ModelCriteria
+     */
+    public function buildModelCriteria()
+    {
+        $query = OrderAddressSocolissimoQuery::create();
+        !(is_null($id = $this->getId())) and $query->filterById(intval($id));
+        return $query;
+    }
+
+    /**
+     * @param LoopResult $loopResult
+     *
+     * @return LoopResult
+     */
+    public function parseResults(LoopResult $loopResult)
+    {
+        /** @var OrderAddressSocolissimo $orderAddressSocolissimo */
+        foreach ($loopResult->getResultDataCollection() as $orderAddressSocolissimo) {
+            $row = new LoopResultRow();
+            $row->set('ID', $orderAddressSocolissimo->getId());
+            $row->set('CODE', $orderAddressSocolissimo->getCode());
+            $row->set('TYPE', $orderAddressSocolissimo->getType());
+            $loopResult->addRow($row);
+        }
+
+        return $loopResult;
+    }
+}

--- a/Loop/SoColissimoOrderAddressLoop.php
+++ b/Loop/SoColissimoOrderAddressLoop.php
@@ -1,10 +1,14 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: ducher
- * Date: 17/06/15
- * Time: 11:18
- */
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
 
 namespace SoColissimo\Loop;
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ Boucles
         Les même sorties que la boucle order, mais avec uniquement les commandes So Colissimo non envoyées.
     - Utilisation:
         ```{loop name="yourloopname" type="order.notsent.socolissimo"}<!-- your template -->{/loop}```
+        
+7. socolissimo.order_address
+	- Argument :
+		1. id | obligatoire | ID de la OrderAddressSoColissimo que l'on veut retrouver grâce à la boucle.
+	- Sorties :
+		1. $ID : ID de la OrderAddressSoColissimo.
+		2. $CODE : code de la OrderAddressSoColissimo.
+		3. $TYPE : type de la OrderAddressSoColissimo.
+	- Utilisation:
+		```{loop name="yourloopname" type="socolissimo.order_address"}<!-- your template -->{/loop}```
 
 Intégration
 -----------
@@ -167,6 +177,16 @@ Loops
         The same as the loop order, but with not sent So Colissimo orders.
     - Usage:
         ```{loop name="yourloopname" type="order.notsent.socolissimo"}<!-- your template -->{/loop}```
+        
+7. socolissimo.order_address
+	- Arguments:
+		1. id | obligatoire | ID of the OrderAddressSoColissimo that should be retrieved by the loop.
+	- Outputs:
+		1. $ID : OrderAddressSoColissimo ID.
+		2. $CODE : OrderAddressSoColissimo code.
+		3. $TYPE : OrderAddressSoColissimo type.
+	- Usage:
+		```{loop name="yourloopname" type="socolissimo.order_address"}<!-- your template -->{/loop}```
 
 
 Integration

--- a/templates/pdf/default/delivery_mode_infos.html
+++ b/templates/pdf/default/delivery_mode_infos.html
@@ -1,0 +1,18 @@
+{loop type='socolissimo.order_address' name='socolissimo.order_address' id=$delivery_address_id}
+    {if {$CODE} == 0}
+        <p>{intl l='Delivered at home.' d='socolissimo.pdf.default'}</p>
+    {else}
+        <p>
+            {intl l='Delivered at a relay.' d='socolissimo.pdf.default'}<br/><br/>
+            <b>{intl l='Relay address:' d='socolissimo.pdf.default'}</b>
+            {loop name='order_address' type='order_address' id=$delivery_address_id}
+            <blockquote>{$COMPANY}<br/>
+                {$ADDRESS1} {$ADDRESS2} {$ADDRESS3}<br/>
+                {$ZIPCODE} {$CITY}<br/>
+                {loop type="country" name="country_delivery" id=$COUNTRY}{$TITLE}{/loop}
+            </blockquote>
+            {/loop}
+            {elseloop rel='order_address'}&nbsp;{intl l='no address' d='socolissimo.pdf.default'}{/elseloop}
+        </p>
+    {/if}
+{/loop}


### PR DESCRIPTION
In order bills, there is currently almost no information about deliveries with So Colissimo. Was it delivered at home? Or at a relay? If the order was delivered at a relay, what are its name and its address? It is currently impossible to know that by reading the PDF order invoice.

This PR aims to solve this issue. Under the name of the delivery module, it makes clear if the order was delivered at home or at a relay. If it is at a relay, the PR adds the relay address.

Technically, the additional information are added through the "`invoice.after-delivery-module`" Thelia's hook. The template used for this is `templates/pdf/default/delivery_mode_infos.html`. The PR also adds a loop called `socolissimo.order_address` which retrieves a single `OrderAddressSoColissimo` thanks to its ID.