### PR TITLE
Bringing back some SoColissimo's Thelia 1 module features

### DIFF
--- a/AdminIncludes/module_configuration.html
+++ b/AdminIncludes/module_configuration.html
@@ -101,6 +101,9 @@
                                     {intl l="REF" d='socolissimo.ai'}
                                 </th>
                                 <th class="object-title">
+                                    {intl l="Customer"}
+                                </th>
+                                <th class="object-title">
                                     {intl l="Date" d='socolissimo.ai'}
                                 </th>
                                 <th class="object-title">
@@ -117,8 +120,16 @@
                                         <tr>
                                             <td>
                                                 <label for="{$label_attr.for}">
-                                                    {$label}
+                                                    <a href="{url path='/admin/order/update/%order_id' order_id={$ID}}">{$label}</a>
                                                 </label>
+                                            </td>
+                                            <td>
+                                                {loop name='order-customer' type='customer' id={$CUSTOMER} current=false}
+                                                    <a href="{url path='/admin/customer/update?customer_id=%customer_id' customer_id={$ID}}">{$FIRSTNAME} {$LASTNAME}</a>
+                                                {/loop}
+                                                {elseloop rel='order-customer'}
+                                                    <a href="{url path='/admin/customer/update?customer_id=%customer_id' customer_id={$CUSTOMER}}">{intl l='Unknown customer' d='socolissimo.ai'}</a>
+                                                {/elseloop}
                                             </td>
                                             <td>
                                                 {$CREATE_DATE|date_format}

--- a/I18n/AdminIncludes/en_US.php
+++ b/I18n/AdminIncludes/en_US.php
@@ -39,5 +39,6 @@ return array(
     'Uncheck all' => 'Uncheck all',
     'Weight up to ... (kg)' => 'Weight up to ... (kg)',
     'operations' => 'operations',
-    "No price for this area" => "No price for this area"
+    "No price for this area" => "No price for this area",
+    'Unknown customer' => 'Unknown customer',
 );

--- a/I18n/AdminIncludes/fr_FR.php
+++ b/I18n/AdminIncludes/fr_FR.php
@@ -42,4 +42,5 @@ return array(
     "No price for this area" => "Aucun prix pour cette zone",
     'Activate total free shipping ' => 'Activer les frais de port gratuits',
     'Or activate free shipping from (€) :' => 'Ou activer les frais de port gratuits à partir de (€)',
+    'Unknown customer' => 'Client inconnu',
 );


### PR DESCRIPTION
This PR aims to bring back two features the SoColissimo module had in Thelia 1 but not in Thelia 2. Those features are both located in the export table located in the module configuration:
- Column with the customer identity and a link to the customer
- Clickable link to the order in the REF column.