### PR TITLE
Fix #26 with issue on payment retry

### DIFF
--- a/Listener/SetDeliveryModule.php
+++ b/Listener/SetDeliveryModule.php
@@ -206,8 +206,6 @@ class SetDeliveryModule implements EventSubscriberInterface
                     ->setCity($tmp_address->getCity())
                     ->save();
 
-                $tmp_address->delete();
-
             } elseif ($request->getSession()->get('SoColissimoRdv') == 1) {
                 $tmp_address = AddressSoColissimoQuery::create()
                     ->findPk($request->getSession()->get('SoColissimoDeliveryId'));
@@ -232,8 +230,6 @@ class SetDeliveryModule implements EventSubscriberInterface
                     ->setCity($tmp_address->getCity())
                     ->setPhone($tmp_address->getCellphone())
                     ->save();
-
-                $tmp_address->delete();
             } else {
                 $tmp_address = AddressSoColissimoQuery::create()
                     ->findPk($request->getSession()->get('SoColissimoDeliveryId'));
@@ -257,8 +253,6 @@ class SetDeliveryModule implements EventSubscriberInterface
                     ->setZipcode($tmp_address->getZipcode())
                     ->setCity($tmp_address->getCity())
                     ->save();
-
-                $tmp_address->delete();
             }
 
         }


### PR DESCRIPTION
This PR fix #26 issue with error on payment retry due to deletion of the address_socolissimo before payment. 

So SoColissimo can't retrieve it when trying to retry the payment an he throw an exception.
```
$tmp_address = AddressSoColissimoQuery::create()
    ->findPk($request->getSession()->get('SoColissimoDeliveryId'));
if ($tmp_address === null) {
    throw new \ErrorException("Got an error with So Colissimo module. Please try again to checkout.");
}
```

I just remove the deletion.