### PR TITLE
Set relay id to an empty string when exporting non-relay orders

### DIFF
--- a/Controller/Export.php
+++ b/Controller/Export.php
@@ -205,7 +205,8 @@ class Export extends BaseAdminController
                                 $cellphone,
                                 $order->getRef(),
                                 $title->getShort(),
-                                $relay_id->getCode(),
+                                // the Expeditor software used to accept a relay id of 0, but no longer does
+                                ($relay_id->getCode() == 0) ? '' : $relay_id->getCode(),
                                 $customer->getEmail(),
                                 $weight,
                                 $store_name,


### PR DESCRIPTION
The Expeditor software for SoColissimo order processing was recently changed and now gives an error if the relay id column is equal to 0 in the exported file. 