### PR TITLE
Version 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-# 1.1.0
+# 1.1.2
 
-- Add import csv for update the orders status
+- Set relay id to an empty string when exporting non-relay orders
 
 # 1.1.1
 
 - Fix routing for the csv export
+
+# 1.1.0
+
+- Add import csv for update the orders status

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -7,7 +7,7 @@
     <descriptive locale="fr_FR">
         <title>So Colissimo</title>
     </descriptive>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <author>
         <name>Thelia</name>
         <email>info@thelia.net</email>


### PR DESCRIPTION
Set relay id to an empty string when exporting non-relay orders