### PR TITLE
Add support for relay search by Thelia address

### DIFF
--- a/Config/routing.xml
+++ b/Config/routing.xml
@@ -36,6 +36,10 @@
         <default key="_controller">SoColissimo\Controller\GetSpecificLocation::getPointInfo</default>
     </route>
 
+    <route id="socolissimo.point.search" path="/module/socolissimo/points">
+        <default key="_controller">SoColissimo\Controller\GetSpecificLocation::search</default>
+    </route>
+
     <route id="socolissimo.export" path="/admin/module/socolissimo/export" methods="post">
         <default key="_controller">SoColissimo\Controller\Export::export</default>
     </route>

--- a/Controller/GetSpecificLocation.php
+++ b/Controller/GetSpecificLocation.php
@@ -69,6 +69,14 @@ class GetSpecificLocation extends BaseFrontController
         return $response;
     }
 
+    public function search()
+    {
+        $zipcode = $this->getRequest()->query->get('zipcode');
+        $city = $this->getRequest()->query->get('city');
+        $addressId = $this->getRequest()->query->get('address');
+
+        return $this->get($zipcode, $city, $addressId);
+    }
 
     /**
      * @return ParserInterface instance parser

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Boucles
     - Arguments:
         1. zipcode | optionnel | code postal de la ville recherchée
         2. city    | optionnel | nom de la ville recherchée
+        3. address | optionnel | id de l'addresse a utiliser pour la recherche.
+            address et zipcode + city ne peuvent pas être présents en même temps.
     - Sorties:
         1. $LONGITUDE: longitude du point relais
         2. $LATITUDE : latitude du point relais
@@ -151,6 +153,8 @@ Loops
     - Arguments:
         1. zipcode | optionnel | zipcode of the searched city
         2. city    | optionnel | name of the searched city
+        3. address | optionnel | id of the address to use for the search.
+        address and zipcode + city cannot be used at the same time.
     - Output:
         1. $LONGITUDE: longitude of the pickup & go store
         2. $LATITUDE : latitude of the pickup & go store

--- a/templates/frontOffice/default/socolissimo.html
+++ b/templates/frontOffice/default/socolissimo.html
@@ -290,35 +290,31 @@
                             }
 
                             function initialize_so() {
-                                // Get customer address
-                                {loop type="address" name="delivery-selection-socolissimo" customer="current" default="true"}
-                                var adr_geoloc = "{$ADDRESS1}, {$ZIPCODE} {$CITY}";
+                                // Get the selected customer address
+                                var $selectedAddressInput = $('#form-cart-delivery')
+                                        .find('[name="thelia_order_delivery[delivery-address]"]')
+                                        .filter(':checked');
+
+                                var selectedAddressId = $selectedAddressInput.val();
+
+                                var locationsSearchUrl = "{url path='/module/socolissimo/points'}";
+
+                                var addresses_geoloc = [];
+                                {loop type="address" name="delivery-selection-socolissimo" customer="current"}
+                                    addresses_geoloc[{$ID}] = "{$ADDRESS1}, {$ZIPCODE} {$CITY}";
                                 {/loop}
+
+                                var adr_geoloc = addresses_geoloc[selectedAddressId];
+
                                 // Get every relay around customer's address
                                 var locations = [];
-
-                                {loop type="socolissimo.around" name="delivery-selection-socolissimo"}
-                                locations.push({
-                                    'name': '{$nom}',
-                                    'lat': {$coordGeolocalisationLatitude},
-                                    'lng': {$coordGeolocalisationLongitude},
-                                    'id': '{$identifiant}',
-                                    'address': '{$adresse1}',
-                                    'zipcode': '{$codePostal}',
-                                    'city': '{$localite}',
-                                    'distance': '{$distance}',
-                                    'type': '{$typeDePoint}',
-                                    'monday': '{$horairesOuvertureLundi}',
-                                    'tuesday': '{$horairesOuvertureMardi}',
-                                    'wednesday': '{$horairesOuvertureMercredi}',
-                                    'thursday': '{$horairesOuvertureJeudi}',
-                                    'friday': '{$horairesOuvertureVendredi}',
-                                    'saturday': '{$horairesOuvertureSamedi}',
-                                    'sunday': '{$horairesOuvertureDimanche}',
-                                    'disabledPerson': '{$accesPersonneMobiliteReduite}'
-                                });
-                                {/loop}
-                                updatemap_socolissimo(adr_geoloc, locations);
+                                $.get(
+                                    locationsSearchUrl + "?address=" + selectedAddressId,
+                                    function(data) {
+                                        locations = data.locations;
+                                        updatemap_socolissimo(adr_geoloc, locations);
+                                    }
+                                );
                             }
 
                             function search_city_socolissimo() {


### PR DESCRIPTION
Allow pick-up relays to be searched again when another delivery address is selected on the delivery page, instead of always selecting the primary address.