### PR TITLE
Fix delivery amount not recalculated correctly (ex when using a coupon)

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -7,7 +7,7 @@
     <descriptive locale="fr_FR">
         <title>So Colissimo</title>
     </descriptive>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <author>
         <name>Thelia</name>
         <email>info@thelia.net</email>

--- a/SoColissimo.php
+++ b/SoColissimo.php
@@ -184,6 +184,19 @@ class SoColissimo extends AbstractDeliveryModule
             $deliveryModeCode = "pr";
         }
 
+        if (null == $deliveryModeCode) {
+            $session = $request->getSession();
+            $dom = $session->get('SoColissimoDomicile');
+            $rdv = $session->get('SoColissimoRdv');
+            $pr_code = $session->get('SoColissimoDeliveryId');
+
+            if ($dom || $rdv) {
+                $deliveryModeCode = "dom";
+            } elseif (!empty($pr_code)) {
+                $deliveryModeCode = "pr";
+            }
+        }
+
         $postage = self::getPostageAmount(
             $country->getAreaId(),
             $cartWeight,


### PR DESCRIPTION
When you have different price for home delivery and relay the mode is passed on request to defined the price. But for exemple when cart price is recalculated for coupon the request mode does not exist and socolissimo take the price of first mode.
This PR search the delivery mode in session if it hasn't been found on request.