### PR TITLE
Fix for when a single relay is found

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -7,7 +7,7 @@
     <descriptive locale="fr_FR">
         <title>So Colissimo</title>
     </descriptive>
-    <version>1.4.8</version>
+    <version>1.4.9</version>
     <author>
         <name>Thelia</name>
         <email>info@thelia.net</email>

--- a/Loop/GetRelais.php
+++ b/Loop/GetRelais.php
@@ -1,7 +1,7 @@
 <?php
 /*************************************************************************************/
 /*                                                                                   */
-/*      Thelia	                                                                     */
+/*      Thelia                                                                       */
 /*                                                                                   */
 /*      Copyright (c) OpenStudio                                                     */
 /*      email : info@thelia.net                                                      */
@@ -17,7 +17,7 @@
 /*      GNU General Public License for more details.                                 */
 /*                                                                                   */
 /*      You should have received a copy of the GNU General Public License            */
-/*	    along with this program. If not, see <http://www.gnu.org/licenses/>.         */
+/*      along with this program. If not, see <http://www.gnu.org/licenses/>.         */
 /*                                                                                   */
 /*************************************************************************************/
 
@@ -119,6 +119,11 @@ class GetRelais extends BaseLoop implements ArraySearchLoopInterface
             $response = array();
         } catch (\SoapFault $e) {
             $response = array();
+        }
+
+        if (!is_array($response) && $response !== null) {
+            $newResponse[] = $response;
+            $response = $newResponse;
         }
 
         return $response;


### PR DESCRIPTION
Fixes an error when a single relay is found.
It used to return a class in function buildArray(), instead of an awaited array or null. The response is now checked and turned into an array if it's a class.